### PR TITLE
Search tweaks

### DIFF
--- a/db.js
+++ b/db.js
@@ -504,19 +504,20 @@ function saveSong(song_id, song_html=$('#song song'), change_url=true) {
         }
         return song_content;
       }
-      let ssearch =  't:' + song.title + '\n'
-                   + 'a:' + formatArray(song.authors, 'a') + '\n'
-                   + 's:' + formatArray(song.scripture_ref, 's') + '\n'
-                   + 'i:' + formatText(song.introduction, 'i') + '\n'
-                   + 'k:' + formatText(song.key, 'k') + '\n'
-                   + 'c:' + formatArray(song.categories, 'c') + '\n'
-                   + 'cp:' + formatText(song.copyright, 'cp') + '\n'
-                   + 'yt:' + formatNumber(song.yt, 'yt') + '\n'
-                   + 'cclis:' + formatNumber(song.cclis, 'cclis') + '\n'
-                   + 'chords:' + formatText(song.chords, 'chords') + '\n'
-                   + formatSongContent(song.content); + '\n'
+      let ssearch =  't:' + song.title + '\0'
+                   + 'a:' + formatArray(song.authors, 'a') + '\0'
+                   + 's:' + formatArray(song.scripture_ref, 's') + '\0'
+                   + 'i:' + formatText(song.introduction, 'i') + '\0'
+                   + 'k:' + formatText(song.key, 'k') + '\0'
+                   + 'c:' + formatArray(song.categories, 'c') + '\0'
+                   + 'cp:' + formatText(song.copyright, 'cp') + '\0'
+                   + 'yt:' + formatNumber(song.yt, 'yt') + '\0'
+                   + 'cclis:' + formatNumber(song.cclis, 'cclis') + '\0'
+                   + 'chords:' + formatText(song.chords, 'chords') + '\0'
+                   + formatSongContent(song.content); + '\0'
 
-      song.search = ssearch.replace(/ +?/g, ' ');
+      song.search = ssearch.replace(/\s{2,}/g, ' ');
+      console.log(song)
 
       db.put(song, function callback(err, result) {
         if (!err) {

--- a/db.js
+++ b/db.js
@@ -476,25 +476,31 @@ function saveSong(song_id, song_html=$('#song song'), change_url=true) {
 
   //Put together Search field.
       let punctuation = /[^a-zA-Z0-9\s:-]/g;
+      let duplicateWhitespace = /\s{2,}/g;
 
       function formatArray(array, letter){
-        return (array != '' ? array.join(' '+letter+':') : '!'+letter);
+        return (array != '' ? array.join(' '+letter+':') : '!'+letter).replace(duplicateWhitespace, ' ');
       }
       function formatText(text, letter){
-        return (text != '' ? text : '!'+letter);
+        return (text != '' ? text : '!'+letter).replace(duplicateWhitespace, ' ');
       }
       function formatNumber(number, letter){
-        return (number != '' ? letter + number : '!'+letter);
+        return (number != '' ? letter + number : '!'+letter).replace(duplicateWhitespace, ' ');
       }
       function formatSongContent(content){
         var song_content = '';
-        
+
         var i, j;
-        for (i = 0; i < content.length; i++) { 
+        for (i = 0; i < content.length; i++) {
           //we are ignoring comments for now
           if(content[i][0].type != 'comment') {
             for (j = 0; j < content[i][1].length; j++ ) {
-              let new_line = escapeRegExp(remove_chords(content[i][1][j]).replace(/\s{2,}/g,' ').replace(punctuation,'').trim() + '\n');
+              let new_line = escapeRegExp(
+                remove_chords(content[i][1][j])
+                .replace(duplicateWhitespace,' ')
+                .replace(punctuation,'')
+                .trim() + '\n'
+              );
               if(song_content.search(new_line) === -1) {
                 //this content is not in the search, add it!
                 song_content += new_line;
@@ -504,7 +510,7 @@ function saveSong(song_id, song_html=$('#song song'), change_url=true) {
         }
         return song_content;
       }
-      let ssearch =  't:' + song.title + '\0'
+      song.search =  't:' + song.title + '\0'
                    + 'a:' + formatArray(song.authors, 'a') + '\0'
                    + 's:' + formatArray(song.scripture_ref, 's') + '\0'
                    + 'i:' + formatText(song.introduction, 'i') + '\0'
@@ -516,7 +522,6 @@ function saveSong(song_id, song_html=$('#song song'), change_url=true) {
                    + 'chords:' + formatText(song.chords, 'chords') + '\0'
                    + formatSongContent(song.content); + '\0'
 
-      song.search = ssearch.replace(/\s{2,}/g, ' ');
       console.log(song)
 
       db.put(song, function callback(err, result) {

--- a/db.js
+++ b/db.js
@@ -494,7 +494,7 @@ function saveSong(song_id, song_html=$('#song song'), change_url=true) {
           //we are ignoring comments for now
           if(content[i][0].type != 'comment') {
             for (j = 0; j < content[i][1].length; j++ ) {
-              let new_line = escapeRegExp(remove_chords(content[i][1][j]).replace(/\s\s+/g,' ').replace(punctuation,'') + '\n');
+              let new_line = escapeRegExp(remove_chords(content[i][1][j]).replace(/\s{2,}/g,' ').replace(punctuation,'').trim() + '\n');
               if(song_content.search(new_line) === -1) {
                 //this content is not in the search, add it!
                 song_content += new_line;

--- a/index.html
+++ b/index.html
@@ -905,7 +905,7 @@
             }
             db_opts += '<option value="create_local">Create Local</option>';
             $('#db_select').html(db_opts).trigger('change');
-            console.log(log_opts);
+            console.log(db_opts);
 
           }).catch(function (err) {
             // handle err

--- a/presentation.html
+++ b/presentation.html
@@ -397,7 +397,7 @@
   <div id="statusbar">
     <div id="searchbox">
       <div id="searchresults"></div>
-      <input id="searchinput" type="text"/><span class="info"></span>
+      <input id="searchinput" type="text" autocomplete="off" /><span class="info"></span>
       <info id="helpButton" onclick="toggleHelp(); endSearch();">?</info>
       </div>
     <div id="progress"></div>

--- a/presentation.js
+++ b/presentation.js
@@ -710,20 +710,29 @@ function escapeAction() {
 }
 
 function processKey(e){ 
+  //console.log("key: '" + e.key +"'", "originalEvent.key: '" + e.originalEvent.key + "'", e);
   key = e.key;
   if((key == '/' || key == 's') & !isSearching()) { 
     e.preventDefault()
   }
 
-  if(e.target.nodeName =='INPUT') {  //workaround for chrome mobile which decided not implement keydown.
-    key = e.data;
-  }
+  // TODO: workaround breaks firefox which the INPUT field has focus
+  // disabling workaround for now, I think it will work as-is on chrome mobile with a bluetooth keyboard
+  // mobile needs a bunch of work before it works well for presentations anyways
+  //if(e.target.nodeName =='INPUT') {  //workaround for chrome mobile which decided not implement keydown.
+  //  console.log('switching to:', e.data);
+  //  key = e.data;
+  //}
 
-  console.log("key: " + key, e);
+  //console.log("key: '" + key +"'", e);
 
   if(key in presentation_key_map){
+  //  console.log("Presentation map function: ", presentation_key_map[key])
     presentation_key_map[key][0](); // call the right function
   }
+  //else {
+  //  console.log("Key '"+key+"' not in presentation map");
+  //}
 
   if(isSearching()){ 
     setTimeout(searchDatabase, 10);

--- a/presentation.js
+++ b/presentation.js
@@ -198,7 +198,7 @@ function toggleChords(touch=false) {
 }
 
 function searchDatabase(){
-  var text = $('#searchbox input').val().replace(/[^a-zA-Z0-9\s:-]/g, '');
+  var text = $('#searchbox input').val();
   if(jQuery.trim(text).length < 2){
     $('#searchresults').empty();
     return;


### PR DESCRIPTION
Bigger changes:
* Changed song save to separate song parts with `\0` instead of `\n`. Search in webapp needed no updates for this, but the presentation mode did. Searches seem to work fine with songs in a mix of '\n' and '\0'.  Main benefit by this change is that searches should work ok even if people use tabs or weird unicode spaces in the songbook.  See comment: https://github.com/yCanta/yCanta2/commit/1b127db1982e2f1a2490e49b137a94c2003580b7#r47093146
* Optimized search in presentation mode to do less work once we've found our top results

Small changes:
* Allow regex in presentation search
* Revert chrome mobile workaround which breaks FF presentation mode

I think this is ready for review and merge.  I did my tests in desktop Firefox and Chromium.
